### PR TITLE
Fix compatibility with Symfony 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,43 @@
 language: php
 
+sudo: false
+
 matrix:
     include:
-        - php: 7.0
+        - php: '7.0'
+          #env: coverage=1
+        - php: '7.1'
+          env: deps='low'
+        #- php: '7.1'
+        #  env: deps='dev'
         # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
         #- php: hhvm-3.12
         #  sudo: required
         #  dist: trusty
         #  group: edge
-        - php: 7.0
-          env: DEPENDENCIES='low'
-        - php: 7.1
-          env: DEPENDENCIES='dev'
     allow_failures:
-        - env: DEPENDENCIES='dev'
-    fast_finish: true
-
-sudo: false
+        - env: deps='dev'
 
 cache:
     directories:
         - $HOME/.composer/cache
 
 before_install:
-    - composer self-update --preview
+    - phpenv config-rm xdebug.ini || echo "xdebug not available"
+    - if [[ $coverage = 1 ]]; then mkdir -p build/logs build/cov; fi
+    - if [[ $coverage = 1 ]]; then wget https://phar.phpunit.de/phpcov.phar; fi
+    - if [[ $coverage = 1 ]]; then wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar; fi
+    - export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 install:
-    - export SYMFONY_DEPRECATIONS_HELPER=strict
-    - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-    - if [ "$DEPENDENCIES" != "low" ]; then travis_retry composer update; fi;
-    - if [ "$DEPENDENCIES" == "low" ]; then travis_retry composer update --prefer-lowest; fi;
+    - if [[ $coverage = 1 ]]; then composer require --dev --no-update 'phpunit/php-code-coverage:^4.0.1'; fi
+    - if [[ ! $deps ]]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi
+    - if [[ $deps = 'dev' ]]; then composer config minimum-stability dev && composer update --prefer-dist --no-progress --no-suggest --ansi ; fi
+    - if [[ $deps = 'low' ]]; then composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi; fi
 
 script:
-    - vendor/bin/phpunit --configuration phpunit.xml.dist --verbose
+    - if [[ $coverage = 1 ]]; then phpdbg -qrr -dmemory_limit=-1 vendor/bin/phpunit  --verbose --coverage-php build/cov/coverage-phpunit.cov; else vendor/bin/phpunit --verbose; fi
+    - if [[ $coverage = 1 ]]; then phpdbg -qrr phpcov.phar merge --clover build/logs/clover.xml build/cov; fi
+
+after_success:
+    - if [[ $coverage = 1 ]]; then travis_retry php coveralls.phar; fi

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
         "symfony/css-selector": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0.0",
         "matthiasnoback/symfony-service-definition-validator": "^1.2.6",
-        "phpunit/phpunit": "^5.6.1",
-        "phpdocumentor/type-resolver": ">=0.2",
-
+        "phpunit/phpunit": "^5.7.5",
         "sllh/php-cs-fixer-styleci-bridge": "^2.1"
     },
     "autoload": {

--- a/src/DependencyInjection/Compiler/TwigRenderEnginePass.php
+++ b/src/DependencyInjection/Compiler/TwigRenderEnginePass.php
@@ -29,14 +29,20 @@ class TwigRenderEnginePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $definitionName = 'twig.loader.filesystem';
+
         if (!$container->hasDefinition('twig.loader.filesystem')) {
-            return;
+            if (!$container->hasDefinition('twig.loader.native_filesystem')) {
+                return;
+            }
+
+            $definitionName = 'twig.loader.native_filesystem';
         }
 
         $reflection = new \ReflectionClass(TwigDatagridExtension::class);
         $extensionFolder = dirname(dirname(dirname($reflection->getFileName())));
 
-        $container->getDefinition('twig.loader.filesystem')->addMethodCall(
+        $container->getDefinition($definitionName)->addMethodCall(
             'addPath',
             [$extensionFolder.'/Resources/theme']
         );

--- a/tests/Functional/Application/AppBundle/Controller/DatagridController.php
+++ b/tests/Functional/Application/AppBundle/Controller/DatagridController.php
@@ -17,6 +17,7 @@ use Rollerworks\Bundle\DatagridBundle\Tests\Functional\Application\AppBundle\Dat
 use Rollerworks\Bundle\DatagridBundle\Tests\Functional\Application\AppBundle\Datagrid\UsersDatagrid;
 use Rollerworks\Component\Datagrid\Extension\Core\Type;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 
 final class DatagridController extends Controller
 {
@@ -49,7 +50,7 @@ final class DatagridController extends Controller
             ['id' => 50, 'firstName' => 'Spider', 'lastName' => 'Big', 'regDate' => new \DateTime('2012-08-05 09:12:00 EST')],
         ]);
 
-        return $this->render('AppBundle::users.html.twig', ['datagrid' => $datagrid->createView()]);
+        return new Response($this->get('twig')->render('@App/users.html.twig', ['datagrid' => $datagrid->createView()]));
     }
 
     public function datagridByClassAction()
@@ -63,7 +64,7 @@ final class DatagridController extends Controller
             ['id' => 50, 'firstName' => 'Spider', 'lastName' => 'Big', 'regDate' => new \DateTime('2012-08-05 09:12:00 EST')],
         ]);
 
-        return $this->render('AppBundle::users.html.twig', ['datagrid' => $datagrid->createView()]);
+        return new Response($this->get('twig')->render('@App/users.html.twig', ['datagrid' => $datagrid->createView()]));
     }
 
     public function datagridByServiceAction()
@@ -75,6 +76,6 @@ final class DatagridController extends Controller
             ['id' => 0, 'firstName' => 'Doctor', 'lastName' => 'Who', 'regDate' => new \DateTime('1980-12-05 12:00:00 EST')],
         ]);
 
-        return $this->render('AppBundle::users.html.twig', ['datagrid' => $datagrid->createView()]);
+        return new Response($this->get('twig')->render('@App/users.html.twig', ['datagrid' => $datagrid->createView()]));
     }
 }

--- a/tests/Functional/Application/config/framework.yml
+++ b/tests/Functional/Application/config/framework.yml
@@ -7,7 +7,6 @@ framework:
     router:
         resource: %kernel.root_dir%/config/routing.yml
         strict_requirements: %kernel.debug%
-    templating:          { engines: [twig] }
     default_locale:      en
     trusted_proxies:     []
     session:


### PR DESCRIPTION
In Symfony 3.3 the templating component is deprecated and Twig must be used directly.